### PR TITLE
try this change to redis connections

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
          "CLIENT_SECRET": { "required": true },
          "SLACK_TOKEN":   { "required": true } },
 "formation": { "web": { "quantity": 1 } },
-"addons": [ "redistogo" ],
+"addons": [ "heroku-redis" ],
 "buildpacks": [ { "url": "heroku/nodejs" } ]
 
 }

--- a/lib/beebot.js
+++ b/lib/beebot.js
@@ -2,9 +2,15 @@
 var botils = require('./botils.js')
 
 if (process.env.REDIS_URL) {
-  var rtg   = require("url").parse(process.env.REDIS_URL)
-  var redis = require("redis").createClient(rtg.port, rtg.hostname)
-  redis.auth(rtg.auth.split(":")[1])
+  //var rtg   = require("url").parse(process.env.REDIS_URL)
+  var redis = require("redis").createClient({
+    url: process.env.REDIS_URL,
+    socket: {
+      tls: true,
+      rejectUnauthorized: false,
+    }
+  })
+  //redis.auth(rtg.auth.split(":")[1])
 } else {
   var redis = require("redis").createClient()
 }

--- a/lib/bid.js
+++ b/lib/bid.js
@@ -11,9 +11,15 @@ const rkey = keyfn("auctions")
 
 
 if (process.env.REDIS_URL) {
-  var rtg   = require("url").parse(process.env.REDIS_URL)
-  var redis = require("redis").createClient(rtg.port, rtg.hostname)
-  redis.auth(rtg.auth.split(":")[1])
+  //var rtg   = require("url").parse(process.env.REDIS_URL)
+  var redis = require("redis").createClient({
+    url: process.env.REDIS_URL,
+    socket: {
+      tls: true,
+      rejectUnauthorized: false,
+    }
+  })
+  //redis.auth(rtg.auth.split(":")[1])
 } else {
   var redis = require("redis").createClient()
 }

--- a/lib/charge.js
+++ b/lib/charge.js
@@ -4,9 +4,15 @@ var beebot = require('./beebot.js');
 var rkey = botils.keyfn("charges");
 
 if (process.env.REDIS_URL) {
-  var rtg   = require("url").parse(process.env.REDIS_URL);
-  var redis = require("redis").createClient(rtg.port, rtg.hostname);
-  redis.auth(rtg.auth.split(":")[1]);
+  //var rtg   = require("url").parse(process.env.REDIS_URL);
+  var redis = require("redis").createClient({
+    url: process.env.REDIS_URL,
+    socket: {
+      tls: true,
+      rejectUnauthorized: false,
+    }
+  })
+  //redis.auth(rtg.auth.split(":")[1]);
 } else {
   var redis = require("redis").createClient();
 }

--- a/lib/karma.js
+++ b/lib/karma.js
@@ -4,9 +4,17 @@ var botils = require('./botils.js')
 var rkey = botils.keyfn("karmabot")
 
 if (process.env.REDIS_URL) {
-  var rtg   = require("url").parse(process.env.REDIS_URL)
-  var redis = require("redis").createClient(rtg.port, rtg.hostname)
-  redis.auth(rtg.auth.split(":")[1])
+  //var rtg   = require("url").parse(process.env.REDIS_URL)
+  var redis = require("redis").createClient({
+    url: process.env.REDIS_URL,
+    socket: {
+      tls: true,
+      rejectUnauthorized: false,
+    }
+  })
+  // TODO: this may not be necessary since we're just giving the url with the
+  // auth token included?
+  //redis.auth(rtg.auth.split(":")[1]) 
 } else {
   var redis = require("redis").createClient()
 }

--- a/lib/tagtime.js
+++ b/lib/tagtime.js
@@ -3,9 +3,15 @@ var https  = require('https')
 var rkey = botils.keyfn("tagtime")
 
 if (process.env.REDIS_URL) {
-  var rtg   = require("url").parse(process.env.REDIS_URL)
-  var redis = require("redis").createClient(rtg.port, rtg.hostname)
-  redis.auth(rtg.auth.split(":")[1])
+  //var rtg   = require("url").parse(process.env.REDIS_URL)
+  var redis = require("redis").createClient({
+    url: process.env.REDIS_URL,
+    socket: {
+      tls: true,
+      rejectUnauthorized: false,
+    }
+  })
+  //redis.auth(rtg.auth.split(":")[1])
 } else {
   var redis = require("redis").createClient()
 }

--- a/lib/tock.js
+++ b/lib/tock.js
@@ -12,9 +12,15 @@ const DEFAULT_TOCK_LENGHTH = 45
 const rkey = keyfn("tockbot")
 
 if (process.env.REDIS_URL) {
-  var rtg   = require("url").parse(process.env.REDIS_URL)
-  var redis = require("redis").createClient(rtg.port, rtg.hostname)
-  redis.auth(rtg.auth.split(":")[1])
+  //var rtg   = require("url").parse(process.env.REDIS_URL)
+  var redis = require("redis").createClient({
+    url: process.env.REDIS_URL,
+    socket: {
+      tls: true,
+      rejectUnauthorized: false
+    }
+  })
+  //redis.auth(rtg.auth.split(":")[1])
   console.log("REDIS case 1")
 } else {
   var redis = require("redis").createClient()

--- a/server.js
+++ b/server.js
@@ -1,9 +1,15 @@
 require('dotenv').load()
 
 if (process.env.REDIS_URL) {
-  var rtg   = require("url").parse(process.env.REDIS_URL)
-  var redis = require("redis").createClient(rtg.port, rtg.hostname)
-  redis.auth(rtg.auth.split(":")[1])
+  //var rtg   = require("url").parse(process.env.REDIS_URL)
+  var redis = require("redis").createClient({
+    url: process.env.REDIS_URL,
+    socket: {
+      tls: true,
+      rejectUnauthorized: false
+    }
+  })
+  //redis.auth(rtg.auth.split(":")[1])
 } else {
   var redis = require("redis").createClient()
 }


### PR DESCRIPTION
per https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-node-js

for #25. 

I'm going to deploy this and debug in production, since production is broken right now anyway... I commented out a call to redis.auth that we used to use, because we're just giving the full URL to `createClient` now, and the URL includes the token... but that might not be right?